### PR TITLE
Switch from --pass-timing to --mlir-timing

### DIFF
--- a/bin/run-firtool.js
+++ b/bin/run-firtool.js
@@ -104,7 +104,7 @@ const firtool = async name => {
       '--lower-to-rtl',
       '--lower-types',
       '--lowering-options=noAlwaysFF',
-      '--pass-timing',
+      '--mlir-timing',
       '--verilog',
       '-o=' + (name + '.v')
     ]);


### PR DESCRIPTION
Update run-firtool.js utility to use the new --mlir-timiing command
line option which replaces the older --pass-timing option.

This should fix the broken CI last night (shown in https://github.com/circt/perf/blob/gh-pages/test1-2021-05-13.log).