### PR TITLE
Update firtool options

### DIFF
--- a/bin/run-firtool.js
+++ b/bin/run-firtool.js
@@ -104,10 +104,6 @@ const firtool = async name => {
     const t0 = Date.now();
     const child = await cp.spawn(firtoolExec, [
       (testPath + '/' + name + '.fir'),
-      '--lower-to-hw',
-      // '--lower-types-v2=1',
-      // '--lowering-options=noAlwaysFF',
-      '--imconstprop',
       '--mlir-timing',
       '--verilog',
       '-o=' + (name + '.v')


### PR DESCRIPTION
perf fails now because `--lower-to-hw` is removed.  
This PR updates firtool options according to https://github.com/llvm/circt/commit/196a3f29995a0a9d38ff9500479dad4ddae2d219. Also remove some out-dated options. 