### PR TITLE
Bump github-deploy-pages 4.0.0 -> v4.4.0

### DIFF
--- a/.github/workflows/web-app.yml
+++ b/.github/workflows/web-app.yml
@@ -23,8 +23,7 @@ jobs:
         npm i
         npm run build
     - name: publish pages 🚀
-      uses: JamesIves/github-pages-deploy-action@4.0.0
+      uses: JamesIves/github-pages-deploy-action@v4.4.0
       with:
-        branch: gh-pages
         folder: docs
         clean: false


### PR DESCRIPTION
Relevant changelogs:

* Add "v" to version tag: https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.2.2
* Option to disable force: https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.3.0
  * Not immediately relevant, but may wish to disable this to avoid dropping commits.
* Workaround issue with new git (>2.36): https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.3.1
* No longer need 'branch' parameter, if using default 'gh-pages': https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.3.4