### PR TITLE
Bump deploy action 4.0.0 -> 4.4.0 for chart-simple workflow as well.

### DIFF
--- a/.github/workflows/chart-simple.yml
+++ b/.github/workflows/chart-simple.yml
@@ -29,8 +29,7 @@ jobs:
       - name: Install rsync 📚
         run: apt-get update && apt-get install -y rsync
       - name: publish pages 🚀
-        uses: JamesIves/github-pages-deploy-action@4.0.0
+        uses: JamesIves/github-pages-deploy-action@4.4.0
         with:
-          branch: gh-pages
           folder: docs
           clean: false


### PR DESCRIPTION
Missed this in #8 .